### PR TITLE
feat: suggest tags for newly created notes (#35)

### DIFF
--- a/src/AiAssistant/NeuroNotes.AiAssistant.Application/TagSuggester.cs
+++ b/src/AiAssistant/NeuroNotes.AiAssistant.Application/TagSuggester.cs
@@ -1,0 +1,90 @@
+using FluentResults;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using NeuroNotes.AiAssistant.Public.Interfaces;
+
+namespace NeuroNotes.AiAssistant.Application;
+
+public sealed class TagSuggester(IChatCompletionService llmChat) : ITagSuggester
+{
+    private const string SystemPrompt =
+        """
+        You help organize notes by tagging them.
+        You are given a note and a fixed list of allowed tags.
+        Choose the tags from the allowed list that best match the note's content.
+
+        Rules:
+        - Pick ONLY tags that appear in the allowed list. Never invent new tags.
+        - Pick only tags that genuinely fit the note. It is fine to pick none.
+        - Return the chosen tags as a single comma-separated line, e.g. "work, ideas".
+        - If no tag fits, return exactly: NONE
+        - Return ONLY the tags (or NONE). No explanations, no extra text.
+        """;
+
+    private const string UserPromptTemplate =
+        """
+        --- ALLOWED TAGS ---
+        {0}
+        --- END ALLOWED TAGS ---
+
+        --- NOTE ---
+        {1}
+        --- END NOTE ---
+        """;
+
+    private static readonly OpenAIPromptExecutionSettings ExecutionSettings = new()
+    {
+        Seed = 42,
+        ResponseFormat = "text"
+    };
+
+    public async Task<Result<IReadOnlyList<string>>> SuggestTags(
+        string noteText,
+        IReadOnlyList<string> availableTags,
+        CancellationToken cancellationToken = default)
+    {
+        if (availableTags.Count == 0)
+        {
+            return Result.Ok<IReadOnlyList<string>>([]);
+        }
+
+        var chatHistory = new ChatHistory();
+        chatHistory.AddSystemMessage(SystemPrompt);
+        chatHistory.AddUserMessage(string.Format(
+            UserPromptTemplate,
+            string.Join(", ", availableTags),
+            noteText));
+
+        var response = await llmChat.GetChatMessageContentAsync(
+            chatHistory: chatHistory,
+            executionSettings: ExecutionSettings,
+            cancellationToken: cancellationToken);
+
+        return Result.Ok(FilterToAvailableTags(response.Content, availableTags));
+    }
+
+    /// <summary>
+    /// Parses the model's free-text answer and keeps only tags that exist in <paramref name="availableTags"/>.
+    /// This is what guarantees no new tag is ever introduced, regardless of what the model returns.
+    /// Matching is case-insensitive; the canonical casing from <paramref name="availableTags"/> is preserved,
+    /// and each tag appears at most once, in the order it appears in <paramref name="availableTags"/>.
+    /// </summary>
+    public static IReadOnlyList<string> FilterToAvailableTags(string? modelResponse, IReadOnlyList<string> availableTags)
+    {
+        if (string.IsNullOrWhiteSpace(modelResponse) || availableTags.Count == 0)
+        {
+            return [];
+        }
+
+        var mentioned = modelResponse
+            .Split([',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(token => token.Trim('#', '-', '•', '"', '\'', ' ', '.'))
+            .Where(token => token.Length > 0)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return availableTags
+            .Where(tag => mentioned.Contains(tag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}

--- a/src/AiAssistant/NeuroNotes.AiAssistant.Infrastructure/Configurations/ServiceInstaller.cs
+++ b/src/AiAssistant/NeuroNotes.AiAssistant.Infrastructure/Configurations/ServiceInstaller.cs
@@ -52,6 +52,7 @@ public static class ServiceInstaller
             services.AddScoped<INoteService, NoteService>();
             services.AddScoped<INoteAssistant, NoteAssistant>();
             services.AddScoped<INoteTextEditor, NoteTextEditor>();
+            services.AddScoped<ITagSuggester, TagSuggester>();
             services.AddSingleton<INoteStore, InMemoryNoteStore>();
             services.AddSingleton<ITagStore, InMemoryTagStore>();
 

--- a/src/AiAssistant/NeuroNotes.AiAssistant.Public/Interfaces/ITagSuggester.cs
+++ b/src/AiAssistant/NeuroNotes.AiAssistant.Public/Interfaces/ITagSuggester.cs
@@ -1,0 +1,15 @@
+using FluentResults;
+
+namespace NeuroNotes.AiAssistant.Public.Interfaces;
+
+/// <summary>
+/// Suggests, for a given note, which of the user's existing tags fit its content.
+/// Only tags from <c>availableTags</c> can be returned — no new tags are ever invented.
+/// </summary>
+public interface ITagSuggester
+{
+    Task<Result<IReadOnlyList<string>>> SuggestTags(
+        string noteText,
+        IReadOnlyList<string> availableTags,
+        CancellationToken cancellationToken = default);
+}

--- a/src/TelegramBot/NeuroNotes.TelegramBot.Application/Commands/CreateNoteCommand.cs
+++ b/src/TelegramBot/NeuroNotes.TelegramBot.Application/Commands/CreateNoteCommand.cs
@@ -9,6 +9,8 @@ public sealed record CreateNoteCommand(Message Message);
 public sealed class CreateNoteCommandHandler(
     ITelegramBotClient telegramBotClient,
     INoteService noteService,
+    ITagStore tagStore,
+    ITagSuggester tagSuggester,
     ILastTranscriptionStore lastTranscriptionStore,
     IChatStateStore chatStateStore) : IConsumer<CreateNoteCommand>
 {
@@ -51,10 +53,34 @@ public sealed class CreateNoteCommandHandler(
 
         chatStateStore.Set(chatId, ChatState.Initial);
 
+        var message = new StringBuilder("Note created.");
+
+        var suggestedTags = await SuggestTags(chatId, createdNote.Markdown, context.CancellationToken);
+        if (suggestedTags.Count > 0)
+        {
+            message.Append("\n\nSuggested tags: ").Append(string.Join(", ", suggestedTags));
+        }
+
+        message.Append("\n\nWhat would you like to do next?");
+
         await telegramBotClient.SendMessage(
             chatId: chatId,
-            text: "Note created. What would you like to do next?",
+            text: message.ToString(),
             replyMarkup: MenuKeyboardFactory.Build(ChatState.Initial),
             cancellationToken: context.CancellationToken);
+    }
+
+    private async Task<IReadOnlyList<string>> SuggestTags(long chatId, string noteText, CancellationToken cancellationToken)
+    {
+        var availableTags = tagStore.GetAll(chatId);
+        if (availableTags.Count == 0)
+        {
+            return [];
+        }
+
+        var result = await tagSuggester.SuggestTags(noteText, availableTags, cancellationToken);
+
+        // Tag suggestions are a nicety — never let a failure here break note creation.
+        return result.IsSuccess ? result.Value : [];
     }
 }

--- a/tests/NeuroNotes.AiAssistant.UnitTests/TagSuggesterTests.cs
+++ b/tests/NeuroNotes.AiAssistant.UnitTests/TagSuggesterTests.cs
@@ -1,0 +1,76 @@
+using NeuroNotes.AiAssistant.Application;
+
+namespace NeuroNotes.AiAssistant.UnitTests;
+
+public class TagSuggesterTests
+{
+    private static readonly string[] AvailableTags = ["work", "ideas", "health"];
+
+    [Fact]
+    public void FilterToAvailableTags_KeepsOnlyTags_FromTheAllowedList()
+    {
+        var result = TagSuggester.FilterToAvailableTags("work, travel, ideas", AvailableTags);
+
+        Assert.Equal(["work", "ideas"], result);
+    }
+
+    [Fact]
+    public void FilterToAvailableTags_NeverInventsNewTags()
+    {
+        var result = TagSuggester.FilterToAvailableTags("travel, cooking, finance", AvailableTags);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FilterToAvailableTags_MatchesCaseInsensitively_AndPreservesCanonicalCasing()
+    {
+        var result = TagSuggester.FilterToAvailableTags("WORK, Ideas", AvailableTags);
+
+        Assert.Equal(["work", "ideas"], result);
+    }
+
+    [Fact]
+    public void FilterToAvailableTags_PreservesAvailableTagOrder()
+    {
+        var result = TagSuggester.FilterToAvailableTags("ideas, work", AvailableTags);
+
+        Assert.Equal(["work", "ideas"], result);
+    }
+
+    [Fact]
+    public void FilterToAvailableTags_DeduplicatesRepeatedTags()
+    {
+        var result = TagSuggester.FilterToAvailableTags("work, work, WORK", AvailableTags);
+
+        Assert.Equal(["work"], result);
+    }
+
+    [Fact]
+    public void FilterToAvailableTags_HandlesNewlineSeparatedAndDecoratedTokens()
+    {
+        var result = TagSuggester.FilterToAvailableTags("- #work\n- #health", AvailableTags);
+
+        Assert.Equal(["work", "health"], result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("NONE")]
+    public void FilterToAvailableTags_ReturnsEmpty_WhenNothingMatches(string? response)
+    {
+        var result = TagSuggester.FilterToAvailableTags(response, AvailableTags);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FilterToAvailableTags_ReturnsEmpty_WhenNoTagsAreAvailable()
+    {
+        var result = TagSuggester.FilterToAvailableTags("work, ideas", []);
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
Closes #35

## Summary
Suggests tags for a note right after it is created. When a user creates a note, the bot asks the LLM which of the user's **existing** tags fit the note's content and shows the matches back to the user. The "no new tags" rule is enforced in code — the suggester intersects the model's output with the user's tag list, so the model can never invent a tag that isn't already in the project.

## Implementation plan
- [x] Add `ITagSuggester` to `AiAssistant.Public` — `SuggestTags(noteText, availableTags)` returning `Result<IReadOnlyList<string>>`
- [x] Implement `TagSuggester` in `AiAssistant.Application` (Semantic Kernel + OpenAI), with a pure static parser that filters the model output to only the available tags (case-insensitive, deduped)
- [x] Register `ITagSuggester` in `AiAssistant.Infrastructure/ServiceInstaller`
- [x] Surface suggested tags in `CreateNoteCommandHandler` after the note document is sent
- [x] Add pure unit tests for the parser/filter logic (the "no new tags" guarantee)
- [x] Build + tests + format green (`dotnet build`, `dotnet test`, `dotnet format --verify-no-changes`)

## Notes for the reviewer
- Suggestions hook into the existing note-creation flow rather than adding a new command, so no new chat state / dispatcher wiring was needed.
- Tags are currently a flat per-user list (no note↔tag association model yet), so suggestions are presented to the user rather than auto-attached. Persisting an attachment can follow once that model exists.
- The board status couldn't be set to *In Progress*: the local `gh` token lacks the `project` scope.
