### PR TITLE
feat: add test-creator subagent for pure xUnit-v3-on-MTP tests (#44)

### DIFF
--- a/.claude/TIER3-PLAN.md
+++ b/.claude/TIER3-PLAN.md
@@ -46,8 +46,11 @@ Definitions tuned to *NeuroNotes* conventions, so the main agent can delegate an
      Telegram input, injection, webhook/Octokit auth.
    - `/review-pr` rewritten to fan all three out over a PR (GitHub MCP) or the local diff and synthesize one
      severity-ranked report. All read-only (`Read, Grep, Glob, Bash`), no Edit/Write.
-2. **`test-author`** — writes **pure** xUnit v3 tests with hand-written fakes (no mocking lib, no
-   network/LLM/Whisper), respecting `OutputType=Exe` + the `--solution` MTP quirk. *(still planned)*
+2. **`test-creator` — DONE (2026-06-06):** writes **pure** xUnit v3 tests with hand-written fakes (no
+   mocking lib, no network/LLM/Whisper/filesystem/real DB), respecting `OutputType=Exe` + the
+   `--solution`/`--project` MTP quirk, and verifies its own output with `dotnet test`. Read/write but
+   scoped to `tests/` — never edits `src/`. Shipped at `.claude/agents/test-creator.md`. *(Renamed from
+   the originally-planned `test-author`.)*
 3. **`module-architect`** — designs new module boundaries honoring the Public/Application/Infrastructure
    layering before any code is written. *(still planned)*
 

--- a/.claude/agents/test-creator.md
+++ b/.claude/agents/test-creator.md
@@ -1,0 +1,83 @@
+---
+name: test-creator
+description: Writes pure xUnit v3 unit tests for NeuroNotes (.NET 10 modular monolith). Use proactively to add or extend test coverage — after implementing or changing public behavior in a module, or when the user asks for tests. Produces pure tests (no network/LLM/Whisper/filesystem/real DB) with hand-written fakes (no mocking library), places them in the module's own test project, and verifies them with the MTP-mode `dotnet test`.
+tools: Read, Grep, Glob, Edit, Write, Bash
+color: green
+---
+
+You write **unit tests** for **NeuroNotes**, a .NET 10 modular monolith (voice-first knowledge base
+delivered as a Telegram bot). You add or extend coverage for a given module/type, then prove the
+tests pass. Unlike the review agents you may edit and create files — but **only** test code under
+`tests/`. Never touch `src/`; if a test reveals a product bug, report it rather than editing the
+code under test.
+
+## When invoked
+1. Identify the target: the type(s) / public behavior to cover. If handed a diff or file list,
+   cover the changed public behavior; otherwise ask the caller for the target or infer it from the
+   most recent change (read-only git: `git diff`, `git log --oneline -n 20`).
+2. Read the type under test **in full**, plus the `*.Public` interfaces of its collaborators, so
+   your fakes match the real contracts and your assertions match real behavior.
+3. Find the module's test project under `tests/NeuroNotes.<Module>.UnitTests`. Read an existing
+   test there (e.g. `TagSuggesterTests.cs`, `PendingGitHubLinkStoreTests.cs`) to match the local
+   style before writing new ones.
+
+## House test rules (non-negotiable — match these exactly)
+- **One project per module.** Tests live in `tests/NeuroNotes.<Module>.UnitTests`, referencing
+  **only** that module's project(s). Never reference another module or the `WebApi` host.
+- **Pure tests only.** No network, no LLM/OpenAI, no Whisper, no FFmpeg, no filesystem, no real
+  database, no clock/`DateTime.Now` dependence, no `Task.Delay`-based timing. A test must be
+  deterministic and run offline.
+- **Hand-written fakes, no mocking library.** Replace collaborators with small `internal sealed`
+  fakes that implement the module's `*.Public` interfaces (e.g. a fake `INoteStore` backed by a
+  `Dictionary`, a fake transcriber returning a canned `Result<T>`). The repo deliberately has **no**
+  mocking library — do not add Moq/NSubstitute/FakeItEasy or any package.
+- **Sanctioned exception:** `NeuroNotes.Persistence.UnitTests` may use the **EF Core in-memory
+  provider** (see `InMemoryDbContextFactory`) to exercise repositories — still no real I/O.
+- **FluentResults:** when testing a method that returns `Result<T>`, assert on `.IsSuccess` /
+  `.IsFailed` / `.Value` / `.Errors`, never on thrown exceptions for expected-failure paths.
+
+## xUnit v3 on Microsoft.Testing.Platform (the gotcha that bites)
+- Test projects are **`<OutputType>Exe</OutputType>`** and reference **`xunit.v3.mtp-v2`** (plus
+  `Microsoft.NET.Test.Sdk`) — versions come from `Directory.Packages.props` (Central Package
+  Management), so add **no** `Version=` on any `PackageReference`.
+- `dotnet test` runs in **MTP mode** (`global.json` sets the runner). Always pass the target
+  explicitly — the legacy positional `dotnet test <path>` no longer works:
+  - whole suite: `dotnet test --solution NeuroNotes.slnx`
+  - one project: `dotnet test --project tests/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`
+- `Xunit` is provided via a project `<Using Include="Xunit"/>`, so `[Fact]`/`[Theory]`/`Assert` need
+  no `using`. Use `[Theory]` + `[InlineData]` for table cases; prefer collection assertions
+  (`Assert.Equal([...], result)`, `Assert.Empty`) over manual loops.
+
+## Scaffolding a new test project (only when the module has none)
+1. Create `tests/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`, copying an
+   existing test `.csproj` as the template: `OutputType=Exe`, `net10.0`, `<Using Include="Xunit"/>`,
+   `PackageReference`s to `Microsoft.NET.Test.Sdk` + `xunit.v3.mtp-v2` (no versions), and a
+   `ProjectReference` to the module project(s) under test.
+2. **Register it in `NeuroNotes.slnx`** next to the sibling test projects — an unregistered project
+   won't run under `dotnet test --solution`.
+3. Delete the `dotnet new` `UnitTest1.cs` placeholder if present.
+
+## C# style (match the codebase)
+File-scoped namespaces; `sealed` types; primary constructors; `var`; expression-bodied members
+where they fit; private fields `_camelCase`; nullable-clean. Common usings belong in the project's
+`<Using>` items / `GlobalUsings`, not repeated per file. Name tests
+`Method_DoesX_WhenY`. Arrange/Act/Assert with blank-line separation, one logical assertion focus
+per test.
+
+## Always verify before reporting
+Run the tests and report the **real** outcome — never claim green without running:
+- `dotnet build NeuroNotes.slnx` (build treats warnings as errors — fix warnings, don't suppress)
+- `dotnet test --project tests/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`
+  (or `--solution NeuroNotes.slnx` when you touched more than one module)
+
+If a test fails because the **code under test** is wrong, do **not** edit `src/` — report the
+suspected product bug (file:line, what's wrong, what you expected) and leave the failing test in
+place only if the caller wants it; otherwise describe the gap.
+
+## Output format
+Report concisely:
+- **Files added/changed** — each test file and any `.csproj` / `.slnx` change, with a one-line note.
+- **What's covered** — the behaviors/edge cases tested and any notable cases deliberately skipped.
+- **Verification** — the exact `dotnet test` command run and its result (e.g. `42/42 passed`), or
+  the failure output verbatim if red.
+- **Follow-ups** — uncovered behavior, suspected product bugs, or anything the caller should decide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,10 +134,11 @@ its own module's project(s).
 - Add a feature to a module → add its tests to that module's project. New module → new test project, registered
   in `NeuroNotes.slnx`. (`/new-module` scaffolds this.)
 
-## Reviewing code (`.claude/agents/`)
+## Subagents (`.claude/agents/`)
 
-Three **read-only** review subagents live in [.claude/agents](.claude/agents) — each reviews a diff through one
-lens and never edits code:
+Specialized subagents live in [.claude/agents](.claude/agents).
+
+Three **read-only** review subagents — each reviews a diff through one lens and never edits code:
 
 - **`code-reviewer`** — correctness, edge cases, null/async handling, error paths, maintainability.
 - **`convention-auditor`** — the house rules in this file (FluentResults, extension-member DI, options pattern,
@@ -150,6 +151,13 @@ Invoke one directly (`@code-reviewer`, or "use the security-reviewer subagent"),
 it fans all three out in parallel over a PR (via GitHub MCP) or the local branch diff and synthesizes one
 severity-ranked report. They deliberately skip style/formatting (the formatter, analyzers, and
 `TreatWarningsAsErrors` already enforce it).
+
+One **test-writing** subagent (read/write, scoped to `tests/`):
+
+- **`test-creator`** — writes **pure** xUnit-v3-on-MTP tests for a given module/type using hand-written fakes
+  (no mocking library, no network/LLM/Whisper/filesystem/real DB), places them in the module's own test project
+  (scaffolding + registering it in `NeuroNotes.slnx` when needed), and verifies them with `dotnet test
+  --solution`/`--project`. Delegate test-writing to it; it never edits `src/`.
 
 ## Configuration & secrets
 

--- a/tests/NeuroNotes.AudioProcessing.UnitTests/NeuroNotes.AudioProcessing.UnitTests.csproj
+++ b/tests/NeuroNotes.AudioProcessing.UnitTests/NeuroNotes.AudioProcessing.UnitTests.csproj
@@ -21,4 +21,8 @@
         <PackageReference Include="xunit.v3.mtp-v2" />
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\AudioProcessing\NeuroNotes.AudioProcessing.Application\NeuroNotes.AudioProcessing.Application.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/tests/NeuroNotes.AudioProcessing.UnitTests/VoiceTranscriberTests.cs
+++ b/tests/NeuroNotes.AudioProcessing.UnitTests/VoiceTranscriberTests.cs
@@ -1,0 +1,81 @@
+using FluentResults;
+
+using NeuroNotes.AudioProcessing.Application;
+using NeuroNotes.AudioProcessing.Application.Interfaces;
+
+namespace NeuroNotes.AudioProcessing.UnitTests;
+
+public class VoiceTranscriberTests
+{
+    [Fact]
+    public async Task Transcribe_ReturnsRecognizedText_WhenConversionAndRecognitionSucceed()
+    {
+        var converter = new FakeAudioConverter(Result.Ok<Stream>(new TrackingStream()));
+        var recognizer = new FakeSpeechRecognizer(Result.Ok("hello world"));
+        var transcriber = new VoiceTranscriber(converter, recognizer);
+
+        var result = await transcriber.Transcribe(new MemoryStream());
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("hello world", result.Value);
+        Assert.True(recognizer.WasCalled);
+    }
+
+    [Fact]
+    public async Task Transcribe_PropagatesFailure_AndSkipsRecognition_WhenConversionFails()
+    {
+        var converter = new FakeAudioConverter(Result.Fail<Stream>("conversion blew up"));
+        var recognizer = new FakeSpeechRecognizer(Result.Ok("should not be returned"));
+        var transcriber = new VoiceTranscriber(converter, recognizer);
+
+        var result = await transcriber.Transcribe(new MemoryStream());
+
+        Assert.True(result.IsFailed);
+        Assert.Equal("conversion blew up", result.Errors.First().Message);
+        Assert.False(recognizer.WasCalled);
+    }
+
+    [Fact]
+    public async Task Transcribe_PropagatesFailure_WhenRecognitionFails()
+    {
+        var wavStream = new TrackingStream();
+        var converter = new FakeAudioConverter(Result.Ok<Stream>(wavStream));
+        var recognizer = new FakeSpeechRecognizer(Result.Fail<string>("recognition blew up"));
+        var transcriber = new VoiceTranscriber(converter, recognizer);
+
+        var result = await transcriber.Transcribe(new MemoryStream());
+
+        Assert.True(result.IsFailed);
+        Assert.Equal("recognition blew up", result.Errors.First().Message);
+        Assert.True(recognizer.WasCalled);
+        Assert.True(wavStream.WasDisposed);
+    }
+
+    private sealed class FakeAudioConverter(Result<Stream> result) : IAudioConverter
+    {
+        public Task<Result<Stream>> ConvertOggToWav(MemoryStream oggData, CancellationToken cancellationToken = default) =>
+            Task.FromResult(result);
+    }
+
+    private sealed class FakeSpeechRecognizer(Result<string> result) : ISpeechRecognizer
+    {
+        public bool WasCalled { get; private set; }
+
+        public Task<Result<string>> RecognizeSpeech(Stream speech, CancellationToken cancellationToken = default)
+        {
+            WasCalled = true;
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class TrackingStream : MemoryStream
+    {
+        public bool WasDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            WasDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Closes #44

## Summary
Adds `test-creator`, the first of the two remaining Tier 3 / work-stream B subagents (the review fleet shipped in #42). It's a delegation target that writes **pure** xUnit-v3-on-MTP tests for a given module/type — hand-written fakes, no mocking library, no I/O — placed in the correct per-module test project and verified with the MTP-mode `dotnet test`. Unlike the three review agents it has `Edit`/`Write`/`Bash` so it can create test files and run them, but it's scoped to `tests/` and never edits `src/`. `module-architect` (the other remaining B subagent) stays out of scope, tracked separately.

## Implementation plan
- [x] Add `.claude/agents/test-creator.md` — proactive-delegation `description`; tools `Read, Grep, Glob, Edit, Write, Bash`; instructions encoding: pure tests (no network/LLM/Whisper/filesystem/real DB), hand-written fakes over the module's interfaces, per-module project placement + `NeuroNotes.slnx` registration when scaffolding, the EF-in-memory exception for Persistence, MTP gotchas (`OutputType=Exe`, `xunit.v3.mtp-v2`, `dotnet test --solution`/`--project`), house C# style, and honest pass/fail reporting.
- [x] Update `CLAUDE.md` agents section to document `test-creator` alongside the review fleet (renamed the section to "Subagents").
- [x] Update `.claude/TIER3-PLAN.md` work-stream B to mark `test-creator` done (noting the `test-author` → `test-creator` rename) and leave `module-architect` still planned.
- [x] Verify the agent end-to-end against a real module (proxy run, since agents are scanned at session start — same approach as #42).
- [x] Build + tests + format green (`dotnet build` Release, `dotnet test --solution` → 79/79, `dotnet format --verify-no-changes` on the touched project).

## End-to-end verification (and a bonus fix)
Ran the agent against the **AudioProcessing** module (which had only a `UnitTest1` placeholder). It:
- Added `tests/NeuroNotes.AudioProcessing.UnitTests/VoiceTranscriberTests.cs` — three pure tests over `VoiceTranscriber` (success path; conversion-failure short-circuits and skips recognition; recognition-failure propagates + wav stream disposed) using `internal sealed` hand-written fakes for `IAudioConverter`/`ISpeechRecognizer`, **no mocking library**.
- Surfaced and fixed a real latent gap: the AudioProcessing test project had **no `ProjectReference` to its module at all** — added it.

These two files are included as the verification artifact: the module's first real tests + the missing reference. Suite went from 76 → **79 tests, all green, 0 warnings**.

## Notes for the reviewer
- Invoking `test-creator` by name needs a `/agents` reload or restart (agents are scanned at session start), hence the proxy verification.
- Reviewer call: I kept the generated `VoiceTranscriberTests.cs` + the csproj `ProjectReference` fix rather than discarding them, since they add genuine value and prove the agent works. Happy to split them into a separate PR if you'd prefer this one stay tooling-only.
