### PR TITLE
fix: correct stale test paths in CLAUDE.md and subagents (#53)

### DIFF
--- a/.claude/agents/convention-auditor.md
+++ b/.claude/agents/convention-auditor.md
@@ -42,8 +42,8 @@ need the authoritative wording. You are read-only: you report findings; you neve
   namespaces, primary constructors, `var`, expression-bodied members where they fit, private fields
   `_camelCase`, nullable-clean. Common usings belong in the module's `GlobalUsings.cs`, not repeated
   per file.
-- **Tests:** under `tests/`, one project per module (`NeuroNotes.<Module>.UnitTests`) referencing
-  **only** that module. Tests are **pure** — no network/LLM/Whisper/filesystem — using small
+- **Tests:** under each module's own `src/<Module>/` directory, one project per module
+  (`NeuroNotes.<Module>.UnitTests`) referencing **only** that module. Tests are **pure** — no network/LLM/Whisper/filesystem — using small
   hand-written fakes (no mocking library). xUnit v3 on Microsoft.Testing.Platform: test projects are
   `OutputType=Exe` referencing `xunit.v3.mtp-v2`. Flag impure tests, an added mocking dependency, a
   feature shipped without tests in its module's project, or a new module with no registered test

--- a/.claude/agents/test-creator.md
+++ b/.claude/agents/test-creator.md
@@ -7,9 +7,10 @@ color: green
 
 You write **unit tests** for **NeuroNotes**, a .NET 10 modular monolith (voice-first knowledge base
 delivered as a Telegram bot). You add or extend coverage for a given module/type, then prove the
-tests pass. Unlike the review agents you may edit and create files — but **only** test code under
-`tests/`. Never touch `src/`; if a test reveals a product bug, report it rather than editing the
-code under test.
+tests pass. Unlike the review agents you may edit and create files — but **only** files inside a
+module's own `*.UnitTests` project (which lives under `src/<Module>/`, alongside — not separate
+from — that module's product code). Never touch a module's non-test code; if a test reveals a
+product bug, report it rather than editing the code under test.
 
 ## When invoked
 1. Identify the target: the type(s) / public behavior to cover. If handed a diff or file list,
@@ -17,12 +18,12 @@ code under test.
    most recent change (read-only git: `git diff`, `git log --oneline -n 20`).
 2. Read the type under test **in full**, plus the `*.Public` interfaces of its collaborators, so
    your fakes match the real contracts and your assertions match real behavior.
-3. Find the module's test project under `tests/NeuroNotes.<Module>.UnitTests`. Read an existing
+3. Find the module's test project under `src/<Module>/NeuroNotes.<Module>.UnitTests`. Read an existing
    test there (e.g. `TagSuggesterTests.cs`, `PendingGitHubLinkStoreTests.cs`) to match the local
    style before writing new ones.
 
 ## House test rules (non-negotiable — match these exactly)
-- **One project per module.** Tests live in `tests/NeuroNotes.<Module>.UnitTests`, referencing
+- **One project per module.** Tests live in `src/<Module>/NeuroNotes.<Module>.UnitTests`, referencing
   **only** that module's project(s). Never reference another module or the `WebApi` host.
 - **Pure tests only.** No network, no LLM/OpenAI, no Whisper, no FFmpeg, no filesystem, no real
   database, no clock/`DateTime.Now` dependence, no `Task.Delay`-based timing. A test must be
@@ -44,13 +45,13 @@ code under test.
 - `dotnet test` runs in **MTP mode** (`global.json` sets the runner). Always pass the target
   explicitly — the legacy positional `dotnet test <path>` no longer works:
   - whole suite: `dotnet test --solution NeuroNotes.slnx`
-  - one project: `dotnet test --project tests/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`
+  - one project: `dotnet test --project src/<Module>/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`
 - `Xunit` is provided via a project `<Using Include="Xunit"/>`, so `[Fact]`/`[Theory]`/`Assert` need
   no `using`. Use `[Theory]` + `[InlineData]` for table cases; prefer collection assertions
   (`Assert.Equal([...], result)`, `Assert.Empty`) over manual loops.
 
 ## Scaffolding a new test project (only when the module has none)
-1. Create `tests/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`, copying an
+1. Create `src/<Module>/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`, copying an
    existing test `.csproj` as the template: `OutputType=Exe`, `net10.0`, `<Using Include="Xunit"/>`,
    `PackageReference`s to `Microsoft.NET.Test.Sdk` + `xunit.v3.mtp-v2` (no versions), and a
    `ProjectReference` to the module project(s) under test.
@@ -68,7 +69,7 @@ per test.
 ## Always verify before reporting
 Run the tests and report the **real** outcome — never claim green without running:
 - `dotnet build NeuroNotes.slnx` (build treats warnings as errors — fix warnings, don't suppress)
-- `dotnet test --project tests/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`
+- `dotnet test --project src/<Module>/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj`
   (or `--solution NeuroNotes.slnx` when you touched more than one module)
 
 If a test fails because the **code under test** is wrong, do **not** edit `src/` — report the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ All commands run from the repo root. The build requires the **.NET 10 SDK**.
 | Build (Debug) | `dotnet build NeuroNotes.slnx` |
 | Build (Release, as CI does) | `dotnet build NeuroNotes.slnx --configuration Release` |
 | Run all tests | `dotnet test --solution NeuroNotes.slnx` |
-| Run one module's tests | `dotnet test --project tests/NeuroNotes.<Module>.UnitTests.csproj` |
+| Run one module's tests | `dotnet test --project src/<Module>/NeuroNotes.<Module>.UnitTests/NeuroNotes.<Module>.UnitTests.csproj` |
 | Format to conventions | `dotnet format NeuroNotes.slnx` |
 | Run the bot (Web host) | `dotnet run --project src/NeuroNotes.WebApi` |
 
@@ -132,13 +132,13 @@ after reading it); encrypted storage is a roadmap item.
 3. Allow it from the right state(s) in `Menus/ChatStateCommandsMap.cs`.
 4. Dispatch to it from `CommandDispatcher` (via `DispatchIfAllowed`), adding a menu button in `MenuButtons` /
    `MenuKeyboardFactory` if the user triggers it from the keyboard.
-5. Add unit tests in that module's test project, `tests/TelegramBot/NeuroNotes.TelegramBot.UnitTests` (the
+5. Add unit tests in that module's test project, `src/TelegramBot/NeuroNotes.TelegramBot.UnitTests` (the
    state-map and keyboard parts are pure and easy to test).
 
 ## Tests
 
-Tests live under `tests/`, **one project per module** (`NeuroNotes.<Module>.UnitTests`), each referencing **only**
-its own module's project(s).
+Tests live under each module's own `src/<Module>/` directory, **one project per module**
+(`NeuroNotes.<Module>.UnitTests`), each referencing **only** its own module's project(s).
 
 - **Stack: xUnit v3 on [Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro) (MTP).**
   Test projects reference `xunit.v3.mtp-v2` and are executables (`<OutputType>Exe</OutputType>`).
@@ -171,12 +171,12 @@ it fans all three out in parallel over a PR (via GitHub MCP) or the local branch
 severity-ranked report. They deliberately skip style/formatting (the formatter, analyzers, and
 `TreatWarningsAsErrors` already enforce it).
 
-One **test-writing** subagent (read/write, scoped to `tests/`):
+One **test-writing** subagent (read/write, scoped to each module's own `*.UnitTests` project under `src/`):
 
 - **`test-creator`** — writes **pure** xUnit-v3-on-MTP tests for a given module/type using hand-written fakes
   (no mocking library, no network/LLM/Whisper/filesystem/real DB), places them in the module's own test project
   (scaffolding + registering it in `NeuroNotes.slnx` when needed), and verifies them with `dotnet test
-  --solution`/`--project`. Delegate test-writing to it; it never edits `src/`.
+  --solution`/`--project`. Delegate test-writing to it; it never touches a module's non-test code.
 
 ## Issue-workflow skills (`.claude/skills/`)
 
@@ -242,6 +242,7 @@ reachable only by the other services on the Compose-created network.
 
 - Touching anything that affects `dotnet restore` at the repo root (the `Directory.*.props` files) also affects the
   Docker build — the Dockerfile copies the full source before `restore` for this reason.
-- Tests in `tests/` are pure and make **no** network/LLM/Whisper calls — keep them that way.
+- Tests (in each module's `*.UnitTests` project under `src/<Module>/`) are pure and make **no**
+  network/LLM/Whisper calls — keep them that way.
 - `SpeechTextEnhancer` is deliberately a *post-processor*, not a chatbot: its system prompt forbids answering the
   text. Preserve that behavior if you edit the prompt.


### PR DESCRIPTION
Closes #53

## Summary

PR #46 moved every module's test project from `tests/NeuroNotes.{Module}.UnitTests` to `src/{Module}/NeuroNotes.{Module}.UnitTests`, but `CLAUDE.md`, `.claude/agents/test-creator.md`, and `.claude/agents/convention-auditor.md` were never updated and still described the old `tests/` layout. This PR is a documentation/instruction-accuracy fix only — no behavior change.

## Implementation plan
- [x] `CLAUDE.md`: fix the 5 stale `tests/NeuroNotes.{Module}.UnitTests` references (commands table, "adding a command" walkthrough, Tests section, subagent description, Gotchas) to `src/{Module}/NeuroNotes.{Module}.UnitTests`
- [x] `.claude/agents/test-creator.md`: fix the discovery step, house rules, both `dotnet test --project` examples, and the scaffolding section to the correct path; reword the "never touch `src/`" boundary so it correctly permits editing `*.UnitTests` files under `src/{Module}/` while still forbidding edits to the module's non-test code
- [x] `.claude/agents/convention-auditor.md`: fix its "under `tests/`" house-rule line to the correct path
- [x] Build + tests green (`dotnet build NeuroNotes.slnx`, `dotnet test --solution NeuroNotes.slnx`, `dotnet format NeuroNotes.slnx --verify-no-changes`)

## Verification
- `dotnet build NeuroNotes.slnx` — 0 warnings, 0 errors
- `dotnet test --solution NeuroNotes.slnx` — 79/79 passed
- `dotnet format NeuroNotes.slnx --verify-no-changes` — clean, exit 0

## Note
While filing #53, GitHub's issue-body handling silently stripped literal `<Module>`-style placeholders (treated as HTML tags even inside code spans) — I've since edited #53 to use `{Module}` instead and used the same in this PR body. The actual repo files (CLAUDE.md, agent `.md` files) keep the original `<Module>` angle-bracket convention, since that stripping only affects GitHub issue/PR body text, not repo file content.